### PR TITLE
Remove required PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,6 @@
 {  
 	"name": "bsscommerce/disable-compare",
 	"description": "Bss Disable Compare Module",
-	"require": {
-		"php": "~5.5.0|~5.6.0|7.0.2|7.0.4|~7.0.6|~7.1.0"
-	},
 	"type": "magento2-module",
 	"version": "1.0.0",
 	"license": [


### PR DESCRIPTION
This is already handled by Magento repositories and when testing 2.2.6 and 2.3 Magento version separately it requires that we add 7.2 when upgrading to 2.3. Suggesting the removal of required PHP as we will need to request a new PHP version be added every few major Magento versions when Magento already handles this.